### PR TITLE
57 ddosx domain property value from file

### DIFF
--- a/cmd/ddosx/ddosx.go
+++ b/cmd/ddosx/ddosx.go
@@ -15,7 +15,7 @@ func DDoSXRootCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 	// Child root commands
 	cmd.AddCommand(ddosxDomainRootCmd(f, fs))
 	cmd.AddCommand(ddosxRecordRootCmd(f))
-	cmd.AddCommand(ddosxSSLRootCmd(f))
+	cmd.AddCommand(ddosxSSLRootCmd(f, fs))
 
 	return cmd
 }

--- a/cmd/ddosx/ddosx_domain.go
+++ b/cmd/ddosx/ddosx_domain.go
@@ -29,7 +29,7 @@ func ddosxDomainRootCmd(f factory.ClientFactory, fs afero.Fs) *cobra.Command {
 	cmd.AddCommand(ddosxDomainRecordRootCmd(f))
 	cmd.AddCommand(ddosxDomainWAFRootCmd(f))
 	cmd.AddCommand(ddosxDomainACLRootCmd(f))
-	cmd.AddCommand(ddosxDomainPropertyRootCmd(f))
+	cmd.AddCommand(ddosxDomainPropertyRootCmd(f, fs))
 	cmd.AddCommand(ddosxDomainVerificationRootCmd(f, fs))
 	cmd.AddCommand(ddosxDomainCDNRootCmd(f))
 	cmd.AddCommand(ddosxDomainHSTSRootCmd(f))

--- a/cmd/ddosx/ddosx_ssl_test.go
+++ b/cmd/ddosx/ddosx_ssl_test.go
@@ -114,7 +114,7 @@ func Test_ddosxSSLCreate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLCreateCmd(nil)
+		cmd := ddosxSSLCreateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 		cmd.Flags().Set("ukfast-ssl-id", "123")
 
@@ -128,7 +128,7 @@ func Test_ddosxSSLCreate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, nil),
 		)
 
-		ddosxSSLCreate(service, cmd, []string{})
+		ddosxSSLCreate(service, cmd, nil, []string{})
 	})
 
 	t.Run("Valid_FromCertificate", func(t *testing.T) {
@@ -136,7 +136,7 @@ func Test_ddosxSSLCreate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLCreateCmd(nil)
+		cmd := ddosxSSLCreateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 		cmd.Flags().Set("key", "testkey1")
 		cmd.Flags().Set("certificate", "testcertificate1")
@@ -154,7 +154,7 @@ func Test_ddosxSSLCreate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, nil),
 		)
 
-		ddosxSSLCreate(service, cmd, []string{})
+		ddosxSSLCreate(service, cmd, nil, []string{})
 	})
 
 	t.Run("CreateSSLError_ReturnsError", func(t *testing.T) {
@@ -163,14 +163,14 @@ func Test_ddosxSSLCreate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLCreateCmd(nil)
+		cmd := ddosxSSLCreateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 
 		gomock.InOrder(
 			service.EXPECT().CreateSSL(gomock.Any()).Return("00000000-0000-0000-0000-000000000000", errors.New("test error")),
 		)
 
-		err := ddosxSSLCreate(service, cmd, []string{})
+		err := ddosxSSLCreate(service, cmd, nil, []string{})
 		assert.Equal(t, "Error creating ssl: test error", err.Error())
 	})
 
@@ -180,7 +180,7 @@ func Test_ddosxSSLCreate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLCreateCmd(nil)
+		cmd := ddosxSSLCreateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 
 		gomock.InOrder(
@@ -188,20 +188,20 @@ func Test_ddosxSSLCreate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, errors.New("test error")),
 		)
 
-		err := ddosxSSLCreate(service, cmd, []string{})
+		err := ddosxSSLCreate(service, cmd, nil, []string{})
 		assert.Equal(t, "Error retrieving new ssl [00000000-0000-0000-0000-000000000000]: test error", err.Error())
 	})
 }
 
 func Test_ddosxSSLUpdateCmd_Args(t *testing.T) {
 	t.Run("ValidArgs_NoError", func(t *testing.T) {
-		err := ddosxSSLUpdateCmd(nil).Args(nil, []string{"00000000-0000-0000-0000-000000000000"})
+		err := ddosxSSLUpdateCmd(nil, nil).Args(nil, []string{"00000000-0000-0000-0000-000000000000"})
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("InvalidArgs_Error", func(t *testing.T) {
-		err := ddosxSSLUpdateCmd(nil).Args(nil, []string{})
+		err := ddosxSSLUpdateCmd(nil, nil).Args(nil, []string{})
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "Missing ssl", err.Error())
@@ -214,7 +214,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLUpdateCmd(nil)
+		cmd := ddosxSSLUpdateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 		cmd.Flags().Set("ukfast-ssl-id", "123")
 
@@ -228,7 +228,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, nil),
 		)
 
-		ddosxSSLUpdate(service, cmd, []string{"00000000-0000-0000-0000-000000000000"})
+		ddosxSSLUpdate(service, cmd, nil, []string{"00000000-0000-0000-0000-000000000000"})
 	})
 
 	t.Run("Valid_Certificate", func(t *testing.T) {
@@ -236,7 +236,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLUpdateCmd(nil)
+		cmd := ddosxSSLUpdateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 		cmd.Flags().Set("key", "testkey1")
 		cmd.Flags().Set("certificate", "testcertificate1")
@@ -254,7 +254,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, nil),
 		)
 
-		ddosxSSLUpdate(service, cmd, []string{"00000000-0000-0000-0000-000000000000"})
+		ddosxSSLUpdate(service, cmd, nil, []string{"00000000-0000-0000-0000-000000000000"})
 	})
 
 	t.Run("UpdateSSLError_ReturnsError", func(t *testing.T) {
@@ -262,14 +262,14 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLUpdateCmd(nil)
+		cmd := ddosxSSLUpdateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 
 		gomock.InOrder(
 			service.EXPECT().PatchSSL("00000000-0000-0000-0000-000000000000", gomock.Any()).Return("00000000-0000-0000-0000-000000000000", errors.New("test error")),
 		)
 
-		err := ddosxSSLUpdate(service, cmd, []string{"00000000-0000-0000-0000-000000000000"})
+		err := ddosxSSLUpdate(service, cmd, nil, []string{"00000000-0000-0000-0000-000000000000"})
 		assert.Equal(t, "Error updating ssl: test error", err.Error())
 	})
 
@@ -278,7 +278,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		service := mocks.NewMockDDoSXService(mockCtrl)
-		cmd := ddosxSSLUpdateCmd(nil)
+		cmd := ddosxSSLUpdateCmd(nil, nil)
 		cmd.Flags().Set("friendly-name", "testssl1")
 
 		gomock.InOrder(
@@ -286,7 +286,7 @@ func Test_ddosxSSLUpdate(t *testing.T) {
 			service.EXPECT().GetSSL("00000000-0000-0000-0000-000000000000").Return(ddosx.SSL{}, errors.New("test error")),
 		)
 
-		err := ddosxSSLUpdate(service, cmd, []string{"00000000-0000-0000-0000-000000000000"})
+		err := ddosxSSLUpdate(service, cmd, nil, []string{"00000000-0000-0000-0000-000000000000"})
 		assert.Equal(t, "Error retrieving updated ssl: test error", err.Error())
 	})
 }

--- a/internal/pkg/helper/flag.go
+++ b/internal/pkg/helper/flag.go
@@ -2,9 +2,11 @@ package helper
 
 import (
 	"errors"
+	"io/ioutil"
 	"strconv"
 	"strings"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/ukfast/cli/internal/pkg/clierrors"
@@ -160,4 +162,19 @@ func GetAPIRequestParametersFromFlags(cmd *cobra.Command) (connection.APIRequest
 			PerPage: viper.GetInt("api_pagination_perpage"),
 		},
 	}, nil
+}
+
+func GetContentsFromFilePathFlag(cmd *cobra.Command, fs afero.Fs, filePathFlag string) (string, error) {
+	filePath, _ := cmd.Flags().GetString(filePathFlag)
+	file, err := fs.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	contentBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(contentBytes), nil
 }


### PR DESCRIPTION
This PR adds flag `--value-file` to the command `ddosx domain property update`, to allow property value to be taken from the contents of a file