### PR TITLE
Add --wait flag to instance power commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.6.1
-	github.com/ukfast/sdk-go v1.4.8
+	github.com/ukfast/sdk-go v1.4.9
 	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/tcnksm/go-gitconfig v0.1.2/go.mod h1:/8EhP4H7oJZdIPyT+/UIsG87kTzrzM4U
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ukfast/go-durationstring v1.0.0 h1:kgPuA7XjLjgLDfkG8j0MpolxcZh/eMdiVoOIFD/uc5I=
 github.com/ukfast/go-durationstring v1.0.0/go.mod h1:Ci81n51kfxlKUIaLY9cINIKRO94VTqV+iCGbOMTb0V8=
-github.com/ukfast/sdk-go v1.4.8 h1:ROAh2r3G5XKb9uoBHvoHOaOpTr8xspAOt68TAz0b7ms=
-github.com/ukfast/sdk-go v1.4.8/go.mod h1:tspweEP77MHhVEYgEEieKAKGITFgwkYl1q5fLh4HZAo=
+github.com/ukfast/sdk-go v1.4.9 h1:MwxQE76YkBVWeAaM5TSKpyAQgJfm0dGYHky9HgTVzh0=
+github.com/ukfast/sdk-go v1.4.9/go.mod h1:tspweEP77MHhVEYgEEieKAKGITFgwkYl1q5fLh4HZAo=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/test/mocks/mock_ecloudservice.go
+++ b/test/mocks/mock_ecloudservice.go
@@ -3878,11 +3878,12 @@ func (mr *MockECloudServiceMockRecorder) PodConsoleAvailable(arg0 interface{}) *
 }
 
 // PowerOffInstance mocks base method
-func (m *MockECloudService) PowerOffInstance(arg0 string) error {
+func (m *MockECloudService) PowerOffInstance(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PowerOffInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PowerOffInstance indicates an expected call of PowerOffInstance
@@ -3906,11 +3907,12 @@ func (mr *MockECloudServiceMockRecorder) PowerOffVirtualMachine(arg0 interface{}
 }
 
 // PowerOnInstance mocks base method
-func (m *MockECloudService) PowerOnInstance(arg0 string) error {
+func (m *MockECloudService) PowerOnInstance(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PowerOnInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PowerOnInstance indicates an expected call of PowerOnInstance
@@ -3934,11 +3936,12 @@ func (mr *MockECloudServiceMockRecorder) PowerOnVirtualMachine(arg0 interface{})
 }
 
 // PowerResetInstance mocks base method
-func (m *MockECloudService) PowerResetInstance(arg0 string) error {
+func (m *MockECloudService) PowerResetInstance(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PowerResetInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PowerResetInstance indicates an expected call of PowerResetInstance
@@ -3962,11 +3965,12 @@ func (mr *MockECloudServiceMockRecorder) PowerResetVirtualMachine(arg0 interface
 }
 
 // PowerRestartInstance mocks base method
-func (m *MockECloudService) PowerRestartInstance(arg0 string) error {
+func (m *MockECloudService) PowerRestartInstance(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PowerRestartInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PowerRestartInstance indicates an expected call of PowerRestartInstance
@@ -3990,11 +3994,12 @@ func (mr *MockECloudServiceMockRecorder) PowerRestartVirtualMachine(arg0 interfa
 }
 
 // PowerShutdownInstance mocks base method
-func (m *MockECloudService) PowerShutdownInstance(arg0 string) error {
+func (m *MockECloudService) PowerShutdownInstance(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PowerShutdownInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PowerShutdownInstance indicates an expected call of PowerShutdownInstance


### PR DESCRIPTION
This PR adds `--wait` flag to the following commands:

* `ecloud instance start`
* `ecloud instance stop`
* `ecloud instance restart`