### PR TITLE
add network flag  to instance create

### DIFF
--- a/cmd/ecloud/ecloud_instance.go
+++ b/cmd/ecloud/ecloud_instance.go
@@ -120,6 +120,8 @@ func ecloudInstanceCreateCmd(f factory.ClientFactory) *cobra.Command {
 	cmd.MarkFlagRequired("ram")
 	cmd.Flags().Int("volume", 0, "Size of volume to allocate")
 	cmd.MarkFlagRequired("volume")
+	cmd.Flags().String("network", "", "ID of network to use for instance")
+	cmd.MarkFlagRequired("network")
 	cmd.Flags().String("image", "", "ID or name of image to deploy from")
 	cmd.MarkFlagRequired("image")
 	cmd.Flags().StringSlice("ssh-key-pair", []string{}, "ID of SSH key pair, can be repeated")
@@ -134,6 +136,7 @@ func ecloudInstanceCreate(service ecloud.ECloudService, cmd *cobra.Command, args
 	createRequest.VCPUCores, _ = cmd.Flags().GetInt("vcpu")
 	createRequest.RAMCapacity, _ = cmd.Flags().GetInt("ram")
 	createRequest.VolumeCapacity, _ = cmd.Flags().GetInt("volume")
+	createRequest.NetworkID, _ = cmd.Flags().GetString("network")
 
 	if cmd.Flags().Changed("name") {
 		createRequest.Name, _ = cmd.Flags().GetString("name")

--- a/cmd/ecloud/ecloud_instance_test.go
+++ b/cmd/ecloud/ecloud_instance_test.go
@@ -166,6 +166,27 @@ func Test_ecloudInstanceCreate(t *testing.T) {
 		assert.Equal(t, "Image not found with name 'unknown'", err.Error())
 	})
 
+	t.Run("CreateWithNetworkID_NoError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		service := mocks.NewMockECloudService(mockCtrl)
+		cmd := ecloudInstanceCreateCmd(nil)
+		cmd.ParseFlags([]string{"--name=testinstance", "--image=img-abcdef12", "--network=net-abcdef12"})
+
+		req := ecloud.CreateInstanceRequest{
+			Name:      "testinstance",
+			ImageID:   "img-abcdef12",
+			NetworkID: "net-abcdef12",
+		}
+
+		service.EXPECT().CreateInstance(req).Return("i-abcdef12", nil)
+		service.EXPECT().GetInstance("i-abcdef12").Return(ecloud.Instance{}, nil)
+
+		err := ecloudInstanceCreate(service, cmd, []string{})
+		assert.Nil(t, err)
+	})
+
 	t.Run("CreateInstanceError_ReturnsError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()


### PR DESCRIPTION
- add `network` as required flag for  `ecloud instance create`